### PR TITLE
Remove word 'commit' in general description of VC

### DIFF
--- a/good-enough-practices-for-scientific-computing.tex
+++ b/good-enough-practices-for-scientific-computing.tex
@@ -807,11 +807,11 @@ Whatever is chosen, we recommend that it be used in the following way:
   assistance for merging simultaneous changes.
 
 \item
-  \recommend{Create, maintain, and use a checklist for committing and
+  \recommend{Create, maintain, and use a checklist for logging and
     sharing changes to the project.}  The list should include writing
-  commit messages that clearly explain any changes, the size and
-  content of single commits, style guidelines for code, updating to-do
-  lists, and bans on committing half-done work or broken code.  See
+  log messages that clearly explain any changes, the size and
+  content of single change sets, style guidelines for code, updating to-do
+  lists, and bans on logging half-done work or broken code.  See
   \cite{gawande2011} for more on the proven value of checklists.
 
 \end{enumerate}
@@ -914,7 +914,7 @@ reliable results.
 
   A version control system stores snapshots of a project's files in a
   repository. Users can modify their working copy of the project at
-  will, and then commit changes to the repository when they wish to
+  will, and then 'commit' changes to the repository when they wish to
   make a permanent record and/or share their work with colleagues. The
   version control system automatically records when the change was
   made and by whom along with the changes themselves.


### PR DESCRIPTION
Before the tool-based version control system is mentioned and version control is explained, the word 'commit' should be avoided. This PR addresses this.
