### PR TITLE
Remove duplicate reference

### DIFF
--- a/good-enough-practices-for-scientific-computing.tex
+++ b/good-enough-practices-for-scientific-computing.tex
@@ -441,10 +441,9 @@ want to make it easy for people to give you credit for your work.
     country is being paid by her government to compile a public health
     report, she will be unable to include your data if the license says
     ``non-commercial''. We recommend permissive software licenses rather
-    than the \withurl{GNU General Public
-      License}{https://www.safaribooksonline.com/library/view/understanding-open-source/0596005814/ch03.html}
-    (GPL) because it is easier to integrate permissively-licensed
-    software into other projects.
+    than the GNU General Public License (GPL) because it is easier to
+    integrate permissively-licensed software into other projects,
+    see chapter three in \cite{laurent2004}.
   \end{quote}
 
 \item


### PR DESCRIPTION
In Collaboration, the footnote https://www.safaribooksonline.com/library/view/understanding-open-source/0596005814/ch03.html is chapter three from the reference

> St Laurent AM (2004) Understanding Open Source and Free Software Licensing. O’Reilly Media.

This PR removes the footnote and replaces it with the reference.
