### PR TITLE
avoid the much-dreaded term 'version control'

### DIFF
--- a/good-enough-practices-for-scientific-computing.tex
+++ b/good-enough-practices-for-scientific-computing.tex
@@ -224,11 +224,11 @@ We organize our recommendations into the following topics:
 \item Project Organization:
   organizing the digital artifacts of a project to ease discovery and understanding.
 
-\item Version Control:
-  keeping track of how various components of your project change over time.
+\item Tracking Changes:
+  recording how various components of your project change over time.
 
 \item Manuscripts:
-  writing manuscripts in a way that easily tracks changes and minimizes manual merging of conflict.
+  writing manuscripts in a way that leaves an audit trail and minimizes manual merging of conflict.
 
 \end{itemize}
 


### PR DESCRIPTION
In a later bulleted list, we successfully avoid the dreaded term "Version control". So I wanted to follow that practice here too. Which then had a small domino effect = required a bit more rewording, in order to not be super repetitive. @gvwilson 
