### PR TITLE
make page narrower

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -13,7 +13,11 @@
   </head>
   <body>
     <div class="container">
-{{ content }}
+      <div class="row">
+        <div class="col-lg-8 col-lg-offset-2 col-md-10 col-md-offset-1">
+          {{ content }}
+        </div>
+      </div>
     </div>
   </body>
 </html>


### PR DESCRIPTION
explanation: bootstrap divides each column into 12 units. By default the content takes the full width of 12 units. What this does is 
- if the page is very wide, use only 8/12 width units, and offset by 2 (so that it's centered)
- if the page is medium width, use 10/12 units and offset by 1
- if the page is narrow, use the default 12/12 units
