### PR TITLE
Update gentzkow2014 URI: one-line change in three files

### DIFF
--- a/good-enough-practices-for-scientific-computing.bib
+++ b/good-enough-practices-for-scientific-computing.bib
@@ -25,7 +25,7 @@
 	title = {Code and Data for the Social Sciences: A Practitioner's Guide},
 	month = {January},
 	year = {2014},
-	url = {http://faculty.chicagobooth.edu/matthew.gentzkow/research/CodeAndData.pdf}
+	url = {http://web.stanford.edu/~gentzkow/research/CodeAndData.pdf}
 }
 
 @misc{hart2015,

--- a/good-enough-practices-for-scientific-computing.tex
+++ b/good-enough-practices-for-scientific-computing.tex
@@ -1277,7 +1277,7 @@ Wilson G, Aruliah DA, Brown CT, Hong NPC, Davis M, Guy RT, et~al.
 Gentzkow M, Shapiro JM. Code and Data for the Social Sciences: A Practitioner's
   Guide; 2014.
 \newblock Available from:
-  \url{http://faculty.chicagobooth.edu/matthew.gentzkow/research/CodeAndData.pdf}.
+  \url{http://web.stanford.edu/~gentzkow/research/CodeAndData.pdf}.
 
 \bibitem{noble2009}
 Noble WS.

--- a/index.md
+++ b/index.md
@@ -1199,7 +1199,7 @@ control:
 
 [wilson2014]: doi:10.1371/journal.pbio.1001745
 
-[gentzkow2014]: http://faculty.chicagobooth.edu/matthew.gentzkow/research/CodeAndData.pdf
+[gentzkow2014]: http://web.stanford.edu/~gentzkow/research/CodeAndData.pdf
 
 [noble2009]: doi:10.1371/journal.pcbi.1000424
 

--- a/index.md
+++ b/index.md
@@ -432,7 +432,7 @@ people to give you credit for your work.
 
     Morris, B.D. and E.P. White. 2013. "The EcoData Retriever:
     improving access to existing ecological data." PLOS ONE 8:e65848.
-    http://doi.org/doi:10.1371/journal.pone.0065848
+    http://doi.org/10.1371/journal.pone.0065848
     ```
 ## Project Organization
 


### PR DESCRIPTION
Dr. Gentzkow evidently moved from U Chicago to Stanford. The old link redirects to his homepage, not the guide itself. I manually replaced the URI, which can save interested readers a few clicks.
- Last functioning Chicago wayback link: http://web.archive.org/web/20150319060602/http://faculty.chicagobooth.edu/matthew.gentzkow/research/CodeAndData.pdf
- Earliest Stanford wayback link: http://web.archive.org/web/20160130054758/http://web.stanford.edu/%7Egentzkow/research/CodeAndData.pdf
